### PR TITLE
add splitter to separate out downloaded data by site

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,8 +1,8 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
-  message(sprintf('  Retrieving data for %s-%s', state, state))
+get_site_data <- function(site_info, state, parameter) {
+
+    message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures
   set.seed(Sys.time()) # Make sure that the seed changes with every run (targets likes to store the seed)

--- a/1_fetch/src/get_state_inventory.R
+++ b/1_fetch/src/get_state_inventory.R
@@ -1,0 +1,5 @@
+get_state_inventory <- function(sites_info, state) {
+
+  site_info <- filter(sites_info, state_cd == state)
+
+}

--- a/_targets.R
+++ b/_targets.R
@@ -9,10 +9,11 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturale
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
+source("1_fetch/src/get_state_inventory.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI','IL')
+states <- c('WI','MN','MI','IL','IN','IA','VT','NH')
 parameter <- c('00060')
 
 # Targets
@@ -22,7 +23,8 @@ list(
 
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, get_state_inventory(sites_info = oldest_active_sites, state_abb)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
#6 
Update code to have a splitter to separate out downloaded data table by site to avoid rebuilding full table when an additional site is added. 
On running pipeline with adding additional sites the already built nwis_data_## targets for previously included states did not get re-built (as expected). The site inventory is still getting rebuilt for each site because it being done before the splitter that was added so addressing that would improve efficiency further.

I added VT and NH because for curiosity :) 
1873 for a gauge in IA !!! 
![site_map](https://user-images.githubusercontent.com/13355628/131162736-f1b53f7b-279e-463f-b94c-6b0250db5d77.png)
